### PR TITLE
Updating peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "trailingComma": "all"
   },
   "peerDependencies": {
-    "apollo-client": "^2.2.3",
+    "apollo-client": "^2.2.6",
     "react": "0.14.x || 15.* || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
@@ -42,7 +42,7 @@
     "@types/recompose": "0.24.5",
     "@types/zen-observable": "0.5.3",
     "apollo-cache-inmemory": "1.1.9",
-    "apollo-client": "2.2.5",
+    "apollo-client": "2.2.6",
     "apollo-link": "1.2.1",
     "babel-core": "6.26.0",
     "babel-jest": "22.4.1",


### PR DESCRIPTION
Updating peer dependencies to squash warnings when running `yarn install`